### PR TITLE
Add support for plain code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,16 +93,12 @@ When a list item contains multiple children the annotation is attached to the ch
   <summary>Code</summary>
 
 ````markdown
+```{{ title: 'Example' }}
+Hello, world!
+```
+
 ```php {{ title: 'Example' }}
 echo 'Hello, world!';
-```
-````
-
-**You must specify a language when annotating a code block.** For plain text you may be able to use any value that doesn't match a valid language, such as `plain`, `text`, or `none`:
-
-````markdown
-```text {{ title: 'Example' }}
-Hello, world!
 ```
 ````
 

--- a/index.js
+++ b/index.js
@@ -14,10 +14,22 @@ export const mdxAnnotations = {
   remark() {
     return (tree) => {
       unistVisit(tree, (node, nodeIndex, parentNode) => {
-        if (node.type === 'code' && /^{\s*{.*?}\s*}$/.test(node.meta)) {
-          setAnnotation(node, node.meta.slice(1, -1))
-          node.meta = null
-          return
+        if (node.type === 'code') {
+          let meta = node.meta ?? ''
+          let lang
+          let annotationIndex = node.lang?.match(/{\s*{/)?.index
+          if (typeof annotationIndex === 'number') {
+            lang = node.lang.slice(0, annotationIndex) || null
+            meta = `${node.lang.slice(annotationIndex)}${meta}`
+          }
+          if (/^{\s*{.*?}\s*}$/.test(meta)) {
+            setAnnotation(node, meta.slice(1, -1))
+            node.meta = null
+            if (typeof lang !== 'undefined') {
+              node.lang = lang
+            }
+            return
+          }
         }
 
         if (node.type === 'tableRow') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,15 @@
         "unist-util-visit": "^4.1.1"
       },
       "devDependencies": {
-        "@mdx-js/mdx": "^2.2.1",
+        "@mdx-js/mdx": "^2.3.0",
         "remark-gfm": "^3.0.1",
         "uvu": "^0.5.6"
       }
     },
     "node_modules/@mdx-js/mdx": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.2.1.tgz",
-      "integrity": "sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.3.0.tgz",
+      "integrity": "sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==",
       "dev": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -1900,9 +1900,9 @@
   },
   "dependencies": {
     "@mdx-js/mdx": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.2.1.tgz",
-      "integrity": "sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.3.0.tgz",
+      "integrity": "sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==",
       "dev": true,
       "requires": {
         "@types/estree-jsx": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "node test.js"
   },
   "devDependencies": {
-    "@mdx-js/mdx": "^2.2.1",
+    "@mdx-js/mdx": "^2.3.0",
     "remark-gfm": "^3.0.1",
     "uvu": "^0.5.6"
   },

--- a/test.js
+++ b/test.js
@@ -21,6 +21,12 @@ test('it works', async () => {
       "- Hello {{ foo: 'bar' }}",
       "- Hello {{ foo: 'bar' }}\n\n  World",
       "```php {{ foo: 'bar' }}\necho '';\n```",
+      "```php{{ foo: 'bar' }}\necho '';\n```",
+      "```php {  { foo: 'bar' } }\necho '';\n```",
+      "```{{foo:'bar'}}\nHello world\n```",
+      "``` {{foo:'bar'}}\nHello world\n```",
+      "```{{ foo: 'bar' }}\nHello world\n```",
+      "``` {{ foo: 'bar' }}\nHello world\n```",
       "Hello **world**{{ foo: 'bar' }}",
       "Hello _world_{{ foo: 'bar' }}",
       "Hello `world`{{ foo: 'bar' }}",
@@ -74,6 +80,50 @@ function _createMdxContent(props) {
       children: _jsx(_components.code, {
         className: "language-php",
         children: "echo '';\\n"
+      }),
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.pre, {
+      children: _jsx(_components.code, {
+        className: "language-php",
+        children: "echo '';\\n"
+      }),
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.pre, {
+      children: _jsx(_components.code, {
+        className: "language-php",
+        children: "echo '';\\n"
+      }),
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.pre, {
+      children: _jsx(_components.code, {
+        children: "Hello world\\n"
+      }),
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.pre, {
+      children: _jsx(_components.code, {
+        children: "Hello world\\n"
+      }),
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.pre, {
+      children: _jsx(_components.code, {
+        children: "Hello world\\n"
+      }),
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.pre, {
+      children: _jsx(_components.code, {
+        children: "Hello world\\n"
       }),
       ...{
         foo: 'bar'


### PR DESCRIPTION
This PR adds support for annotations on "plain" code blocks (code blocks where a language is not specified):

````markdown
```{{ foo: 'bar' }}
Hello, world!
```
````