### PR TITLE
Add support for thematic breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ echo 'Hello, world!';
 ```markdown
 --- {{ className: 'my-10' }}
 
-\*\*\* {{ className: 'my-10' }}
+*** {{ className: 'my-10' }}
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ echo 'Hello, world!';
 </details>
 
 <details>
+  <summary>Thematic breaks</summary>
+
+```markdown
+--- {{ className: 'my-10' }}
+
+\*\*\* {{ className: 'my-10' }}
+```
+
+</details>
+
+<details>
   <summary>Inline elements</summary>
 
 To annotate an inline element ensure that there is no whitespace between the element and the annotation:

--- a/index.js
+++ b/index.js
@@ -10,6 +10,12 @@ function setAnnotation(node, annotation) {
   props[PROP_NAME] = annotation
 }
 
+function isThematicBreak(str) {
+  if (!str) return false
+  let trimmed = str.trim()
+  return trimmed === '---' || trimmed === '***'
+}
+
 export const mdxAnnotations = {
   remark() {
     return (tree) => {
@@ -42,6 +48,19 @@ export const mdxAnnotations = {
             setAnnotation(parentNode, node.children[0].children[0].value)
             parentNode.children.splice(nodeIndex, 1)
           }
+          return
+        }
+
+        if (
+          node.type === 'paragraph' &&
+          node.children.length === 2 &&
+          node.children[0].type === 'text' &&
+          isThematicBreak(node.children[0].value) &&
+          node.children[1].type === 'mdxTextExpression'
+        ) {
+          node.type = 'thematicBreak'
+          setAnnotation(node, node.children[1].value)
+          delete node.children
           return
         }
 

--- a/test.js
+++ b/test.js
@@ -32,6 +32,10 @@ test('it works', async () => {
       "Hello `world`{{ foo: 'bar' }}",
       "Hello [world](#){{ foo: 'bar' }}",
       "![](/img.png){{ foo: 'bar' }}",
+      "--- {{ foo: 'bar' }}",
+      "*** {{ foo: 'bar' }}",
+      "---{{ foo: 'bar' }}",
+      "***{{ foo: 'bar' }}",
     ].join('\n\n')
   )
 
@@ -50,7 +54,8 @@ function _createMdxContent(props) {
     strong: "strong",
     em: "em",
     a: "a",
-    img: "img"
+    img: "img",
+    hr: "hr"
   }, props.components);
   return _jsxs(_Fragment, {
     children: [_jsx(_components.h1, {
@@ -165,6 +170,22 @@ function _createMdxContent(props) {
           foo: 'bar'
         }
       })
+    }), "\\n", _jsx(_components.hr, {
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.hr, {
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.hr, {
+      ...{
+        foo: 'bar'
+      }
+    }), "\\n", _jsx(_components.hr, {
+      ...{
+        foo: 'bar'
+      }
     })]
   });
 }


### PR DESCRIPTION
**Example:**

```markdown
--- {{ className: 'my-10' }}

*** {{ className: 'my-10' }}
```

> **Note**
> Thematic breaks with spaces between the `-`/`*` characters are not currently supported.