### PR TITLE
Handle case where object expression has spread element without keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ export const mdxAnnotations = {
         let propsNode = node.arguments[1]
         if (propsNode?.type !== 'ObjectExpression') return
 
-        let propNode = propsNode.properties.find((property) => property.key.name === PROP_NAME)
+        let propNode = propsNode.properties.find((property) => property.key && property.key.name === PROP_NAME)
 
         if (propNode) {
           let annotationNode = acorn.parse('(' + propNode.value.value.trim() + ')', {


### PR DESCRIPTION
Small patch to avoid getting errors when seeing object expressions containing spread elements without keys like these:

```json
{
  "type": "ObjectExpression",
  "properties": [
    {
      "type": "SpreadElement",
      "argument": {
        "type": "Identifier",
        "name": "props"
      }
    }
  ]
}
```

As far as I understand the code here, skipping any properties without a key should be totally fine, but let me know if we need to do some extra work to identify them.